### PR TITLE
Add initial component interfaces & basic node rendering

### DIFF
--- a/public/component_types/base_interfaces.ts
+++ b/public/component_types/base_interfaces.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY } from '../utils';
+
+/**
+ * ************ Types **************************
+ */
+
+// TODO: may change some/all of these to enums later
+export type BaseClass = string;
+export type UIFlow = string;
+export type FieldType = 'string' | 'json' | 'select';
+
+/**
+ * ************ Base interfaces ****************
+ */
+
+/**
+ * Represents a single base class as an input handle for a component.
+ * It may be optional. It may also accept multiples of that class.
+ */
+export interface IComponentInput {
+  id: string;
+  label: string;
+  baseClass: string;
+  optional: boolean;
+  acceptMultiple: boolean;
+}
+
+/**
+ * An input field for a component. Specifies enough configuration for the
+ * UI node to render it properly within the component (show it as optional,
+ * put it in advanced settings, placeholder values, etc.)
+ */
+export interface IComponentField {
+  label: string;
+  type: FieldType;
+  placeholder?: string;
+  optional?: boolean;
+  advanced?: boolean;
+}
+
+/**
+ * Represents the list of base classes as a single output handle for
+ * a component.
+ */
+export interface IComponentOutput {
+  id: string;
+  label: string;
+  baseClasses: BaseClass[];
+}
+
+/**
+ * The base interface the components will implement.
+ */
+export interface IComponent {
+  id: string;
+  type: BaseClass;
+  label: string;
+  description: string;
+  // will be used for grouping together in the drag-and-drop component library
+  category: COMPONENT_CATEGORY;
+  // determines if this component allows for new creation. this means to
+  // allow a "create" option on the UI component, as well as potentially
+  // include in the use case template construction ('provisioning' flow)
+  allowsCreation: boolean;
+  // determines if this is something that will be included in the use
+  // case template construction (query or ingest flows). provisioning flow
+  // is handled by the allowsCreation flag above.
+  isApplicationStep: boolean;
+  // the set of allowed flows this component can be drug into the workspace
+  allowedFlows: UIFlow[];
+  // the list of base classes that will be used in the component output
+  baseClasses?: BaseClass[];
+  inputs?: IComponentInput[];
+  fields?: IComponentField[];
+  // if the component supports creation, we will have a different set of input fields
+  // the user needs to fill out
+  createFields?: IComponentField[];
+  outputs?: IComponentOutput[];
+  // we will need some init function when the component is drug into the workspace
+  init?(): Promise<any>;
+}

--- a/public/component_types/index.ts
+++ b/public/component_types/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './base_interfaces';
+export * from './processors';
+export * from './indices';

--- a/public/component_types/indices/index.ts
+++ b/public/component_types/indices/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './knn_index';

--- a/public/component_types/indices/knn_index.ts
+++ b/public/component_types/indices/knn_index.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY } from '../../utils';
+import {
+  IComponent,
+  IComponentField,
+  IComponentInput,
+  IComponentOutput,
+  UIFlow,
+  BaseClass,
+} from '../base_interfaces';
+
+/**
+ * A k-NN index UI component
+ */
+export class KnnIndex implements IComponent {
+  id: string;
+  type: BaseClass;
+  label: string;
+  description: string;
+  category: COMPONENT_CATEGORY;
+  allowsCreation: boolean;
+  isApplicationStep: boolean;
+  allowedFlows: UIFlow[];
+  baseClasses: BaseClass[];
+  inputs: IComponentInput[];
+  fields: IComponentField[];
+  createFields: IComponentField[];
+  outputs: IComponentOutput[];
+
+  constructor() {
+    this.id = 'knn_index';
+    this.type = 'knn_index';
+    this.label = 'k-NN Index';
+    this.description = 'A k-NN Index to be used as a vector store';
+    this.category = COMPONENT_CATEGORY.INDICES;
+    this.allowsCreation = true;
+    this.isApplicationStep = false;
+    // TODO: 'other' may not be how this is stored. the idea is 'other' allows
+    // for placement outside of the ingest or query flows- typically something
+    // that will be referenced/used as input across multiple flows
+    this.allowedFlows = ['Ingest', 'Query', 'Other'];
+    this.baseClasses = [this.type];
+    this.inputs = [];
+    this.fields = [
+      {
+        label: 'Index Name',
+        type: 'select',
+        optional: false,
+        advanced: false,
+      },
+    ];
+    this.createFields = [
+      {
+        label: 'Index Name',
+        type: 'string',
+        optional: false,
+        advanced: false,
+      },
+      // we don't need to expose "settings" here since it will be index.knn by default
+      // just let users customize the mappings
+      // TODO: figure out how to handle defaults for all of these values. maybe toggle between
+      // simple form inputs vs. complex JSON editor
+      {
+        label: 'Mappings',
+        type: 'json',
+        placeholder: 'Enter an index mappings JSON blob...',
+        optional: false,
+        advanced: false,
+      },
+    ];
+    this.outputs = [
+      {
+        id: this.id,
+        label: this.label,
+        baseClasses: this.baseClasses,
+      },
+    ];
+  }
+
+  async init(): Promise<any> {
+    return new KnnIndex();
+  }
+}

--- a/public/component_types/processors/index.ts
+++ b/public/component_types/processors/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './text_embedding_processor';

--- a/public/component_types/processors/text_embedding_processor.ts
+++ b/public/component_types/processors/text_embedding_processor.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY } from '../../utils';
+import {
+  IComponent,
+  IComponentField,
+  IComponentInput,
+  IComponentOutput,
+  UIFlow,
+  BaseClass,
+} from '../base_interfaces';
+
+/**
+ * A text embedding processor UI component
+ */
+export class TextEmbeddingProcessor implements IComponent {
+  id: string;
+  type: BaseClass;
+  label: string;
+  description: string;
+  category: COMPONENT_CATEGORY;
+  allowsCreation: boolean;
+  isApplicationStep: boolean;
+  allowedFlows: UIFlow[];
+  baseClasses: BaseClass[];
+  inputs: IComponentInput[];
+  fields: IComponentField[];
+  outputs: IComponentOutput[];
+
+  constructor() {
+    this.id = 'text_embedding_processor';
+    this.type = 'text_embedding_processor';
+    this.label = 'Text Embedding Processor';
+    this.description =
+      'A text embedding ingest processor to be used in an ingest pipeline';
+    this.category = COMPONENT_CATEGORY.INGEST_PROCESSORS;
+    this.allowsCreation = false;
+    this.isApplicationStep = false;
+    this.allowedFlows = ['Ingest'];
+    this.baseClasses = [this.type];
+    this.inputs = [];
+    this.fields = [
+      {
+        label: 'Model ID',
+        type: 'string',
+        optional: false,
+        advanced: false,
+      },
+      {
+        label: 'Input Field',
+        type: 'string',
+        optional: false,
+        advanced: false,
+      },
+      {
+        label: 'Output Field',
+        type: 'string',
+        optional: false,
+        advanced: false,
+      },
+    ];
+    this.outputs = [
+      {
+        id: this.id,
+        label: this.label,
+        baseClasses: this.baseClasses,
+      },
+    ];
+  }
+
+  async init(): Promise<any> {
+    return new TextEmbeddingProcessor();
+  }
+}

--- a/public/pages/workflow_builder/components/index.ts
+++ b/public/pages/workflow_builder/components/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './input_fields';
+export { NewOrExistingTabs } from './new_or_existing_tabs';
+export { InputFieldList } from './input_field_list';

--- a/public/pages/workflow_builder/components/input_field_list.tsx
+++ b/public/pages/workflow_builder/components/input_field_list.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { IComponentField } from '../../../component_types';
+import { TextField, JsonField, SelectField } from './input_fields';
+
+/**
+ * A helper component to format all of the input fields for a component. Dynamically
+ * render based on the input type.
+ */
+
+interface InputFieldListProps {
+  inputFields?: IComponentField[];
+}
+
+export function InputFieldList(props: InputFieldListProps) {
+  return (
+    <EuiFlexItem>
+      {props.inputFields?.map((field, idx) => {
+        let el;
+        switch (field.type) {
+          case 'string': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <TextField
+                  label={field.label}
+                  placeholder={field.placeholder || ''}
+                />
+                <EuiSpacer size="s" />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'json': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <JsonField
+                  label={field.label}
+                  placeholder={field.placeholder || ''}
+                />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'select': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <SelectField />
+              </EuiFlexItem>
+            );
+            break;
+          }
+        }
+        return el;
+      })}
+    </EuiFlexItem>
+  );
+}

--- a/public/pages/workflow_builder/components/input_fields/index.ts
+++ b/public/pages/workflow_builder/components/input_fields/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { TextField } from './text_field';
+export { JsonField } from './json_field';
+export { SelectField } from './select_field';

--- a/public/pages/workflow_builder/components/input_fields/json_field.tsx
+++ b/public/pages/workflow_builder/components/input_fields/json_field.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiText, EuiTextArea } from '@elastic/eui';
+
+interface JsonFieldProps {
+  label: string;
+  placeholder: string;
+}
+
+/**
+ * An input field for a component where users manually enter
+ * in some custom JSON
+ */
+export function JsonField(props: JsonFieldProps) {
+  return (
+    <>
+      <EuiText size="s" className="eui-textLeft">
+        {props.label}
+      </EuiText>
+      <EuiTextArea placeholder={props.placeholder} />
+    </>
+  );
+}

--- a/public/pages/workflow_builder/components/input_fields/select_field.tsx
+++ b/public/pages/workflow_builder/components/input_fields/select_field.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { EuiSuperSelect, EuiSuperSelectOption, EuiText } from '@elastic/eui';
+
+// TODO: Should be fetched from global state.
+// Need to have a way to determine where to fetch this dynamic data.
+const existingIndices = [
+  {
+    value: 'index-1',
+    inputDisplay: <EuiText>my-index-1</EuiText>,
+    disabled: false,
+  },
+  {
+    value: 'index-2',
+    inputDisplay: <EuiText>my-index-2</EuiText>,
+    disabled: false,
+  },
+] as Array<EuiSuperSelectOption<string>>;
+
+/**
+ * An input field for a component where users select from a list of available
+ * options.
+ */
+export function SelectField() {
+  const options = existingIndices;
+
+  const [selectedOption, setSelectedOption] = useState<string>(
+    options[0].value
+  );
+
+  const onChange = (option: string) => {
+    setSelectedOption(option);
+  };
+
+  return (
+    <EuiSuperSelect
+      options={options}
+      valueOfSelected={selectedOption}
+      onChange={(option) => onChange(option)}
+    />
+  );
+}

--- a/public/pages/workflow_builder/components/input_fields/text_field.tsx
+++ b/public/pages/workflow_builder/components/input_fields/text_field.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFieldText } from '@elastic/eui';
+
+interface TextFieldProps {
+  label: string;
+  placeholder: string;
+}
+
+/**
+ * An input field for a component where users input plaintext
+ */
+export function TextField(props: TextFieldProps) {
+  return (
+    <EuiFieldText
+      prepend={props.label}
+      compressed={false}
+      placeholder={props.placeholder || ''}
+    />
+  );
+}

--- a/public/pages/workflow_builder/components/new_or_existing_tabs.tsx
+++ b/public/pages/workflow_builder/components/new_or_existing_tabs.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiTab, EuiTabs } from '@elastic/eui';
+
+/**
+ * A helper component containing the togglable 'New' vs. 'Existing' tabs.
+ */
+
+interface NewOrExistingTabsProps {
+  selectedTabId: string;
+  setSelectedTabId(tabId: string): void;
+}
+
+const inputTabs = [
+  {
+    id: 'existing',
+    name: 'Existing',
+    disabled: false,
+  },
+  {
+    id: 'new',
+    name: 'New',
+    disabled: false,
+  },
+];
+
+export function NewOrExistingTabs(props: NewOrExistingTabsProps) {
+  return (
+    <EuiTabs size="s" expand={true}>
+      {inputTabs.map((tab, idx) => {
+        return (
+          <EuiTab
+            onClick={() => props.setSelectedTabId(tab.id)}
+            isSelected={tab.id === props.selectedTabId}
+            disabled={tab.disabled}
+            key={idx}
+          >
+            {tab.name}
+          </EuiTab>
+        );
+      })}
+    </EuiTabs>
+  );
+}

--- a/public/pages/workflow_builder/index.ts
+++ b/public/pages/workflow_builder/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { WorkflowBuilder } from './workflow_builder';
+export { WorkflowComponent } from './workflow_component';

--- a/public/pages/workflow_builder/workflow_builder.tsx
+++ b/public/pages/workflow_builder/workflow_builder.tsx
@@ -10,12 +10,17 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiText,
   EuiSpacer,
 } from '@elastic/eui';
 import { BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
 // import { AppState, removeDirty, setComponents } from '../../store';
+import {
+  TextEmbeddingProcessor,
+  IComponent,
+  KnnIndex,
+} from '../../component_types';
+import { WorkflowComponent } from './workflow_component';
 
 export function WorkflowBuilder() {
   // TODO: below commented out lines can be used for fetching & setting global redux state
@@ -31,6 +36,12 @@ export function WorkflowBuilder() {
     ]);
   });
 
+  // TODO: Should be fetched from global state. Using some defaults for testing purposes
+  const curComponents = [
+    new TextEmbeddingProcessor(),
+    new KnnIndex(),
+  ] as IComponent[];
+
   return (
     <div>
       <EuiPageHeader>
@@ -43,9 +54,15 @@ export function WorkflowBuilder() {
         </EuiFlexGroup>
       </EuiPageHeader>
       <EuiSpacer size="l" />
-      <EuiFlexItem>
-        <EuiText>Workspace</EuiText>
-      </EuiFlexItem>
+      <EuiFlexGroup direction="row">
+        {curComponents.map((component, idx) => {
+          return (
+            <EuiFlexItem key={idx}>
+              <WorkflowComponent component={component} />
+            </EuiFlexItem>
+          );
+        })}
+      </EuiFlexGroup>
     </div>
   );
 }

--- a/public/pages/workflow_builder/workflow_component.tsx
+++ b/public/pages/workflow_builder/workflow_component.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiSpacer,
+  EuiCard,
+} from '@elastic/eui';
+import { IComponent } from '../../component_types';
+import { InputFieldList, NewOrExistingTabs } from './components';
+
+interface WorkflowComponentProps {
+  component: IComponent;
+}
+
+/**
+ * TODO: This will be the ReactFlow node in the drag-and-drop workspace. It will take in a component
+ * from the global workflow state and render it appropriately (inputs / params / outputs / etc.)
+ * Similar to Flowise's CanvasNode - see
+ * https://github.com/FlowiseAI/Flowise/blob/main/packages/ui/src/views/canvas/CanvasNode.js
+ */
+export function WorkflowComponent(props: WorkflowComponentProps) {
+  const { component } = props;
+
+  const [selectedTabId, setSelectedTabId] = useState<string>('existing');
+
+  const isCreatingNew = component.allowsCreation && selectedTabId === 'new';
+  const fieldsToDisplay = isCreatingNew
+    ? component.createFields
+    : component.fields;
+
+  return (
+    <EuiCard title={component.label} style={{ maxWidth: '40vh' }}>
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          {component.allowsCreation ? (
+            <NewOrExistingTabs
+              setSelectedTabId={setSelectedTabId}
+              selectedTabId={selectedTabId}
+            />
+          ) : undefined}
+        </EuiFlexItem>
+        <InputFieldList inputFields={fieldsToDisplay} />
+        {/**
+         * Hardcoding the interfaced inputs/outputs for readability
+         * TODO: remove when moving this into the context of a ReactFlow node with Handles.
+         */}
+        <EuiFlexItem>
+          <>
+            <EuiText>
+              <b>Inputs:</b>
+            </EuiText>
+            {component.inputs?.map((input, idx) => {
+              return <EuiText key={idx}>{input.label}</EuiText>;
+            })}
+            <EuiSpacer size="s" />
+            <EuiText>
+              <b>Outputs:</b>
+            </EuiText>
+            {component.outputs?.map((output, idx) => {
+              return <EuiText key={idx}>{output.label}</EuiText>;
+            })}
+          </>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiCard>
+  );
+}

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -28,3 +28,8 @@ export const BREADCRUMBS = Object.freeze({
     href: `#${APP_PATH.WORKFLOW_BUILDER}`,
   },
 });
+
+export enum COMPONENT_CATEGORY {
+  INGEST_PROCESSORS = 'Ingest Processors',
+  INDICES = 'Indices',
+}


### PR DESCRIPTION
### Description

This PR accomplishes 3 main things:
1. Sets up the base interfaces that will represent all of the different building blocks / UI components users will select to construct workflows.
2. Implements interfaces for 2 components: 1/ a text embedding processor, and 2/ a k-NN index.
3. Sets up a basic `WorkflowComponent` React component that's purpose is to take in a component instance (a particular k-NN index, for example), and dynamically render based on its configuration. An example with more details is shown below.


Example:
- shows the same `WorkflowComponent` building out instances of a text embedding processor and a k-NN index.
- k-NN index component supports creation, so it has a tabbed portion to toggle the inputs based on if user wants to create a new index, or use existing
- based on the input types, renders differently (text vs. select vs. JSON, etc.)
- inputs/outputs displayed there for readability & debugging purposes
- dummy values used for the indices and the created components

[screen-capture (15).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/5200eacb-e792-4de9-a8d7-7b8bb87d9b7b)

Adding a `rapid` label to indicate this PR may not be perfectly clean or have tests. It is for rapid iteration.

### Issues Resolved

Makes progress on #4. 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
