### PR TITLE
Set up redux infrastructure

### DIFF
--- a/public/pages/workflow_builder/workflow_builder.tsx
+++ b/public/pages/workflow_builder/workflow_builder.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect } from 'react';
+// import { useSelector, useDispatch } from 'react-redux';
 import {
   EuiPageHeader,
   EuiFlexGroup,
@@ -14,8 +15,15 @@ import {
 } from '@elastic/eui';
 import { BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
+// import { AppState, removeDirty, setComponents } from '../../store';
 
 export function WorkflowBuilder() {
+  // TODO: below commented out lines can be used for fetching & setting global redux state
+  // const dispatch = useDispatch();
+  // const { isDirty, components } = useSelector(
+  //   (state: AppState) => state.workspace
+  // );
+
   useEffect(() => {
     getCore().chrome.setBreadcrumbs([
       BREADCRUMBS.AI_APPLICATION_BUILDER,
@@ -36,7 +44,7 @@ export function WorkflowBuilder() {
       </EuiPageHeader>
       <EuiSpacer size="l" />
       <EuiFlexItem>
-        <EuiText>Placeholder for workflow builder page...</EuiText>
+        <EuiText>Workspace</EuiText>
       </EuiFlexItem>
     </div>
   );

--- a/public/render_app.tsx
+++ b/public/render_app.tsx
@@ -6,17 +6,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import { AppMountParameters, CoreStart } from '../../../src/core/public';
 import { AiFlowDashboardsApp } from './app';
+import { store } from './store';
 
 export const renderApp = (
   coreStart: CoreStart,
   { appBasePath, element }: AppMountParameters
 ) => {
   ReactDOM.render(
-    <Router basename={appBasePath + '#/'}>
-      <Route render={(props) => <AiFlowDashboardsApp {...props} />} />
-    </Router>,
+    <Provider store={store}>
+      <Router basename={appBasePath + '#/'}>
+        <Route render={(props) => <AiFlowDashboardsApp {...props} />} />
+      </Router>
+    </Provider>,
     element
   );
 

--- a/public/store/index.ts
+++ b/public/store/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './store';
+export * from './reducers';

--- a/public/store/reducers/index.ts
+++ b/public/store/reducers/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './workspace_reducer';

--- a/public/store/reducers/workspace_reducer.ts
+++ b/public/store/reducers/workspace_reducer.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  isDirty: false,
+  components: [],
+};
+
+const workspaceSlice = createSlice({
+  name: 'workspace',
+  initialState,
+  reducers: {
+    setDirty(state) {
+      state.isDirty = true;
+    },
+    removeDirty(state) {
+      state.isDirty = false;
+    },
+    setComponents(state, action) {
+      state.components = action.payload;
+      state.isDirty = true;
+    },
+  },
+});
+
+export const workspaceReducer = workspaceSlice.reducer;
+export const { setDirty, removeDirty, setComponents } = workspaceSlice.actions;

--- a/public/store/store.ts
+++ b/public/store/store.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers } from 'redux';
+import { workspaceReducer } from './reducers';
+
+const rootReducer = combineReducers({
+  workspace: workspaceReducer,
+});
+export const store = configureStore({
+  reducer: rootReducer,
+});
+
+export type AppState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
### Description

Sets up the initial redux infrastructure for maintaining frontend state. We choose to use redux / react-redux / redux-toolkit libraries since it is the consistent way that core OSD + other plugins use, and is the standard across modern react applications. It also doesn't add any dependencies since we consume them from core OSD.
- sets up global redux store via `configureStore`
- sets up basic workspace reducer to process workspace-related state updates via `createSlice`
- wraps the entire app within a `Provider` so React components have access to the store
- sets up sample cmds for future reference as ways to access and set the store in the base `WorkflowBuilder` page

Tested with some basic functionalities, including adding some dummy components, and validating if there are changes. These are using the `components` and `isDirty` vars within the `workspace` state.

[screen-capture (16).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/56c1b67d-4251-405f-9eb0-6feefee54676)

### Issues Resolved

Makes progress on #8 & #10

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
