### PR TITLE
Add input and output handles to components

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -6,3 +6,4 @@
 export * from './constants';
 export * from './interfaces';
 export * from '../public/component_types';
+export * from '../public/utils';

--- a/public/component_types/indices/knn_index.ts
+++ b/public/component_types/indices/knn_index.ts
@@ -44,7 +44,15 @@ export class KnnIndex implements IComponent {
     // that will be referenced/used as input across multiple flows
     this.allowedFlows = ['Ingest', 'Query', 'Other'];
     this.baseClasses = [this.type];
-    this.inputs = [];
+    this.inputs = [
+      {
+        id: 'text-embedding-processor',
+        label: 'Text embedding processor',
+        baseClass: 'text_embedding_processor',
+        optional: false,
+        acceptMultiple: false,
+      },
+    ];
     this.fields = [
       {
         label: 'Index Name',

--- a/public/component_types/indices/knn_index.ts
+++ b/public/component_types/indices/knn_index.ts
@@ -3,37 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { COMPONENT_CATEGORY } from '../../utils';
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../../utils';
 import {
   IComponent,
   IComponentField,
   IComponentInput,
   IComponentOutput,
   UIFlow,
-  BaseClass,
 } from '../interfaces';
 
 /**
  * A k-NN index UI component
  */
 export class KnnIndex implements IComponent {
-  id: string;
-  type: BaseClass;
+  type: COMPONENT_CLASS;
   label: string;
   description: string;
   category: COMPONENT_CATEGORY;
   allowsCreation: boolean;
   isApplicationStep: boolean;
   allowedFlows: UIFlow[];
-  baseClasses: BaseClass[];
+  baseClasses: COMPONENT_CLASS[];
   inputs: IComponentInput[];
   fields: IComponentField[];
   createFields: IComponentField[];
   outputs: IComponentOutput[];
 
   constructor() {
-    this.id = 'knn_index';
-    this.type = 'knn_index';
+    this.type = COMPONENT_CLASS.KNN_INDEX;
     this.label = 'k-NN Index';
     this.description = 'A k-NN Index to be used as a vector store';
     this.category = COMPONENT_CATEGORY.INDICES;
@@ -48,7 +45,7 @@ export class KnnIndex implements IComponent {
       {
         id: 'text-embedding-processor',
         label: 'Text embedding processor',
-        baseClass: 'text_embedding_processor',
+        baseClass: COMPONENT_CLASS.TEXT_EMBEDDING_PROCESSOR,
         optional: false,
         acceptMultiple: false,
       },
@@ -82,7 +79,6 @@ export class KnnIndex implements IComponent {
     ];
     this.outputs = [
       {
-        id: this.id,
         label: this.label,
         baseClasses: this.baseClasses,
       },

--- a/public/component_types/interfaces.ts
+++ b/public/component_types/interfaces.ts
@@ -22,7 +22,7 @@ export type FieldType = 'string' | 'json' | 'select';
 export interface IComponentInput {
   id: string;
   label: string;
-  baseClass: string;
+  baseClass: COMPONENT_CLASS;
   optional: boolean;
   acceptMultiple: boolean;
 }

--- a/public/component_types/interfaces.ts
+++ b/public/component_types/interfaces.ts
@@ -3,14 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { COMPONENT_CATEGORY } from '../utils';
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../utils';
 
 /**
  * ************ Types **************************
  */
-
-// TODO: may change some/all of these to enums later
-export type BaseClass = string;
 export type UIFlow = string;
 export type FieldType = 'string' | 'json' | 'select';
 
@@ -48,17 +45,15 @@ export interface IComponentField {
  * a component.
  */
 export interface IComponentOutput {
-  id: string;
   label: string;
-  baseClasses: BaseClass[];
+  baseClasses: COMPONENT_CLASS[];
 }
 
 /**
  * The base interface the components will implement.
  */
 export interface IComponent {
-  id: string;
-  type: BaseClass;
+  type: COMPONENT_CLASS;
   label: string;
   description: string;
   // will be used for grouping together in the drag-and-drop component library
@@ -74,7 +69,7 @@ export interface IComponent {
   // the set of allowed flows this component can be drug into the workspace
   allowedFlows: UIFlow[];
   // the list of base classes that will be used in the component output
-  baseClasses?: BaseClass[];
+  baseClasses?: COMPONENT_CLASS[];
   inputs?: IComponentInput[];
   fields?: IComponentField[];
   // if the component supports creation, we will have a different set of input fields

--- a/public/component_types/processors/text_embedding_processor.ts
+++ b/public/component_types/processors/text_embedding_processor.ts
@@ -3,36 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { COMPONENT_CATEGORY } from '../../utils';
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../../utils';
 import {
   IComponent,
   IComponentField,
   IComponentInput,
   IComponentOutput,
   UIFlow,
-  BaseClass,
 } from '../interfaces';
 
 /**
  * A text embedding processor UI component
  */
 export class TextEmbeddingProcessor implements IComponent {
-  id: string;
-  type: BaseClass;
+  type: COMPONENT_CLASS;
   label: string;
   description: string;
   category: COMPONENT_CATEGORY;
   allowsCreation: boolean;
   isApplicationStep: boolean;
   allowedFlows: UIFlow[];
-  baseClasses: BaseClass[];
+  baseClasses: COMPONENT_CLASS[];
   inputs: IComponentInput[];
   fields: IComponentField[];
   outputs: IComponentOutput[];
 
   constructor() {
-    this.id = 'text_embedding_processor';
-    this.type = 'text_embedding_processor';
+    this.type = COMPONENT_CLASS.TEXT_EMBEDDING_PROCESSOR;
     this.label = 'Text Embedding Processor';
     this.description =
       'A text embedding ingest processor to be used in an ingest pipeline';
@@ -64,7 +61,6 @@ export class TextEmbeddingProcessor implements IComponent {
     ];
     this.outputs = [
       {
-        id: this.id,
         label: this.label,
         baseClasses: this.baseClasses,
       },

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -10,7 +10,11 @@
 }
 
 .workspace {
-  width: 50vh;
+  width: 80vh;
   height: 50vh;
   padding: 0;
+}
+
+.workspace-component {
+  width: 300px;
 }

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -13,7 +13,8 @@ import ReactFlow, {
 } from 'reactflow';
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { rfContext } from '../../../store';
-import { Workflow } from '../../../../common';
+import { IComponent, Workflow } from '../../../../common';
+import { generateId } from '../../../utils';
 import { getCore } from '../../../services';
 import { WorkspaceComponent } from '../workspace_component';
 
@@ -54,7 +55,9 @@ export function Workspace(props: WorkspaceProps) {
     (event) => {
       event.preventDefault();
       // Get the node info from the event metadata
-      const nodeData = event.dataTransfer.getData('application/reactflow');
+      const nodeData = event.dataTransfer.getData(
+        'application/reactflow'
+      ) as IComponent;
 
       // check if the dropped element is valid
       if (typeof nodeData === 'undefined' || !nodeData) {
@@ -72,13 +75,12 @@ export function Workspace(props: WorkspaceProps) {
       });
 
       // TODO: remove hardcoded values when more component info is passed in the event.
-      // Only keep the calculated 'positioning' field.
+      // Only keep the calculated 'position' field.
       const newNode = {
-        // TODO: generate ID based on the node data maybe
-        id: Date.now().toFixed(),
+        id: generateId(nodeData.type),
         type: nodeData.type,
         position,
-        data: { label: nodeData.label },
+        data: nodeData,
         style: {
           background: 'white',
         },

--- a/public/pages/workflow_detail/workspace_component/input_handle.tsx
+++ b/public/pages/workflow_detail/workspace_component/input_handle.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useRef, useEffect, useContext } from 'react';
+import { Connection, Handle, Position } from 'reactflow';
+import { EuiText } from '@elastic/eui';
+import { IComponent, IComponentInput } from '../../../component_types';
+import { calculateHandlePosition, isValidConnection } from './utils';
+import { rfContext } from '../../../store';
+
+interface InputHandleProps {
+  data: IComponent;
+  input: IComponentInput;
+}
+
+export function InputHandle(props: InputHandleProps) {
+  const ref = useRef(null);
+  const { reactFlowInstance } = useContext(rfContext);
+  const [position, setPosition] = useState<number>(0);
+
+  useEffect(() => {
+    setPosition(calculateHandlePosition(ref));
+  }, [ref]);
+
+  return (
+    <div ref={ref}>
+      <>
+        <EuiText textAlign="left">{props.input.label}</EuiText>
+        <Handle
+          type="target"
+          id={props.input.baseClass}
+          position={Position.Left}
+          isValidConnection={(connection: Connection) =>
+            isValidConnection(connection, reactFlowInstance)
+          }
+          style={{
+            height: 10,
+            width: 10,
+            backgroundColor: 'black',
+            top: position,
+          }}
+        />
+      </>
+    </div>
+  );
+}

--- a/public/pages/workflow_detail/workspace_component/input_handle.tsx
+++ b/public/pages/workflow_detail/workspace_component/input_handle.tsx
@@ -33,6 +33,7 @@ export function InputHandle(props: InputHandleProps) {
           id={props.input.baseClass}
           position={Position.Left}
           isValidConnection={(connection: Connection) =>
+            // @ts-ignore
             isValidConnection(connection, reactFlowInstance)
           }
           style={{

--- a/public/pages/workflow_detail/workspace_component/output_handle.tsx
+++ b/public/pages/workflow_detail/workspace_component/output_handle.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useRef, useEffect, useContext } from 'react';
+import { Connection, Handle, Position } from 'reactflow';
+import { EuiText } from '@elastic/eui';
+import { IComponent, IComponentOutput } from '../../../component_types';
+import { calculateHandlePosition, isValidConnection } from './utils';
+import { rfContext } from '../../../store';
+
+interface OutputHandleProps {
+  data: IComponent;
+  output: IComponentOutput;
+}
+
+export function OutputHandle(props: OutputHandleProps) {
+  const ref = useRef(null);
+  const { reactFlowInstance } = useContext(rfContext);
+  const [position, setPosition] = useState<number>(0);
+  const outputClasses = props.output.baseClasses.join('|');
+
+  useEffect(() => {
+    setPosition(calculateHandlePosition(ref));
+  }, [ref]);
+
+  return (
+    <div ref={ref}>
+      <>
+        <EuiText textAlign="right">{props.output.label}</EuiText>
+        <Handle
+          type="source"
+          id={outputClasses}
+          position={Position.Right}
+          isValidConnection={(connection: Connection) =>
+            isValidConnection(connection, reactFlowInstance)
+          }
+          style={{
+            height: 10,
+            width: 10,
+            backgroundColor: 'black',
+            top: position,
+          }}
+        />
+      </>
+    </div>
+  );
+}

--- a/public/pages/workflow_detail/workspace_component/output_handle.tsx
+++ b/public/pages/workflow_detail/workspace_component/output_handle.tsx
@@ -34,6 +34,7 @@ export function OutputHandle(props: OutputHandleProps) {
           id={outputClasses}
           position={Position.Right}
           isValidConnection={(connection: Connection) =>
+            // @ts-ignore
             isValidConnection(connection, reactFlowInstance)
           }
           style={{

--- a/public/pages/workflow_detail/workspace_component/utils.ts
+++ b/public/pages/workflow_detail/workspace_component/utils.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Connection, ReactFlowInstance } from 'reactflow';
+import { IComponentInput } from '../../../../common';
+
+/**
+ * Collection of utility functions for the workspace component
+ */
+
+// Uses DOM elements to calculate where the handle should be placed
+// vertically on the ReactFlow component. offsetTop is the offset relative to the
+// parent element, and clientHeight is the element height including padding.
+// We can combine them to get the exact amount, in pixels.
+export function calculateHandlePosition(ref: any): number {
+  if (ref.current && ref.current.offsetTop && ref.current.clientHeight) {
+    return ref.current.offsetTop + ref.current.clientHeight / 2;
+  } else {
+    return 0;
+  }
+}
+
+export function isValidConnection(
+  connection: Connection,
+  rfInstance: ReactFlowInstance
+): boolean {
+  const sourceHandle = connection.sourceHandle;
+  const targetHandle = connection.targetHandle;
+  const targetNodeId = connection.target;
+
+  const inputClass = sourceHandle || '';
+  // We store the output classes in a pipe-delimited string. Converting back to a list.
+  const outputClasses = targetHandle?.split('|') || [];
+
+  if (outputClasses?.includes(inputClass)) {
+    const targetNode = rfInstance.getNode(targetNodeId || '');
+    if (targetNode) {
+      // We pull out the relevant IComponentInput config, and check if it allows multiple connections.
+      // We also check the existing edges in the ReactFlow state.
+      // If there is an existing edge, and we don't allow multiple, we don't allow this connection.
+      // For all other scenarios, we allow the connection.
+      const inputConfig = targetNode.data.inputs.find(
+        (input: IComponentInput) => input.baseClass === inputClass
+      );
+      const existingEdge = rfInstance
+        .getEdges()
+        .find((edge) => edge.targetHandle === targetHandle);
+      if (existingEdge && inputConfig.acceptMultiple === false) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/public/pages/workflow_detail/workspace_component/utils.ts
+++ b/public/pages/workflow_detail/workspace_component/utils.ts
@@ -22,6 +22,9 @@ export function calculateHandlePosition(ref: any): number {
   }
 }
 
+// Validates that connections can only be made when the source and target classes align, and
+// that multiple connections to the same target handle are not allowed unless the input configuration
+// for that particular component allows for it.
 export function isValidConnection(
   connection: Connection,
   rfInstance: ReactFlowInstance
@@ -29,7 +32,6 @@ export function isValidConnection(
   const sourceHandle = connection.sourceHandle;
   const targetHandle = connection.targetHandle;
   const targetNodeId = connection.target;
-
   const inputClass = sourceHandle || '';
   // We store the output classes in a pipe-delimited string. Converting back to a list.
   const outputClasses = targetHandle?.split('|') || [];
@@ -37,13 +39,9 @@ export function isValidConnection(
   if (outputClasses?.includes(inputClass)) {
     const targetNode = rfInstance.getNode(targetNodeId || '');
     if (targetNode) {
-      // We pull out the relevant IComponentInput config, and check if it allows multiple connections.
-      // We also check the existing edges in the ReactFlow state.
-      // If there is an existing edge, and we don't allow multiple, we don't allow this connection.
-      // For all other scenarios, we allow the connection.
       const inputConfig = targetNode.data.inputs.find(
         (input: IComponentInput) => input.baseClass === inputClass
-      );
+      ) as IComponentInput;
       const existingEdge = rfInstance
         .getEdges()
         .find((edge) => edge.targetHandle === targetHandle);

--- a/public/pages/workflow_detail/workspace_component/utils.ts
+++ b/public/pages/workflow_detail/workspace_component/utils.ts
@@ -32,19 +32,23 @@ export function isValidConnection(
   const sourceHandle = connection.sourceHandle;
   const targetHandle = connection.targetHandle;
   const targetNodeId = connection.target;
-  const inputClass = sourceHandle || '';
-  // We store the output classes in a pipe-delimited string. Converting back to a list.
-  const outputClasses = targetHandle?.split('|') || [];
 
-  if (outputClasses?.includes(inputClass)) {
+  // We store the output classes in a pipe-delimited string. Converting back to a list.
+  const sourceClasses = sourceHandle?.split('|') || [];
+  const targetClass = targetHandle || '';
+
+  if (sourceClasses?.includes(targetClass)) {
     const targetNode = rfInstance.getNode(targetNodeId || '');
     if (targetNode) {
       const inputConfig = targetNode.data.inputs.find(
-        (input: IComponentInput) => input.baseClass === inputClass
+        (input: IComponentInput) => sourceClasses.includes(input.baseClass)
       ) as IComponentInput;
       const existingEdge = rfInstance
         .getEdges()
-        .find((edge) => edge.targetHandle === targetHandle);
+        .find(
+          (edge) =>
+            edge.target === targetNodeId && edge.targetHandle === targetHandle
+        );
       if (existingEdge && inputConfig.acceptMultiple === false) {
         return false;
       }

--- a/public/pages/workflow_detail/workspace_component/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace_component/workspace_component.tsx
@@ -4,16 +4,12 @@
  */
 
 import React, { useState } from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiSpacer,
-  EuiCard,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiCard } from '@elastic/eui';
 import { IComponent } from '../../../component_types';
 import { InputFieldList } from './input_field_list';
 import { NewOrExistingTabs } from './new_or_existing_tabs';
+import { InputHandle } from './input_handle';
+import { OutputHandle } from './output_handle';
 
 interface WorkspaceComponentProps {
   data: IComponent;
@@ -35,38 +31,31 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
     : component.fields;
 
   return (
-    <EuiCard title={component.label} style={{ maxWidth: '40vh' }}>
+    <EuiCard title={component.label} className="workspace-component">
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
+        {/* <EuiFlexItem>
           {component.allowsCreation ? (
             <NewOrExistingTabs
               setSelectedTabId={setSelectedTabId}
               selectedTabId={selectedTabId}
             />
           ) : undefined}
-        </EuiFlexItem>
+        </EuiFlexItem> */}
+        {component.inputs?.map((input, index) => {
+          return (
+            <EuiFlexItem key={index}>
+              <InputHandle input={input} data={component} />
+            </EuiFlexItem>
+          );
+        })}
         <InputFieldList inputFields={fieldsToDisplay} />
-        {/**
-         * Hardcoding the interfaced inputs/outputs for readability
-         * TODO: remove when moving this into the context of a ReactFlow node with Handles.
-         */}
-        <EuiFlexItem>
-          <>
-            <EuiText>
-              <b>Inputs:</b>
-            </EuiText>
-            {component.inputs?.map((input, idx) => {
-              return <EuiText key={idx}>{input.label}</EuiText>;
-            })}
-            <EuiSpacer size="s" />
-            <EuiText>
-              <b>Outputs:</b>
-            </EuiText>
-            {component.outputs?.map((output, idx) => {
-              return <EuiText key={idx}>{output.label}</EuiText>;
-            })}
-          </>
-        </EuiFlexItem>
+        {component.outputs?.map((output, index) => {
+          return (
+            <EuiFlexItem key={index}>
+              <OutputHandle output={output} data={component} />
+            </EuiFlexItem>
+          );
+        })}
       </EuiFlexGroup>
     </EuiCard>
   );

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -10,24 +10,25 @@ import {
   ReactFlowEdge,
   KnnIndex,
   TextEmbeddingProcessor,
+  generateId,
 } from '../../../common';
 
 // TODO: remove after fetching from server-side
 const dummyNodes = [
   {
-    id: 'text-embedding-processor',
+    id: generateId('text_embedding_processor'),
     position: { x: 0, y: 500 },
     data: new TextEmbeddingProcessor(),
     type: 'customComponent',
   },
   {
-    id: 'text-embedding-processor-2',
+    id: generateId('text_embedding_processor'),
     position: { x: 0, y: 200 },
     data: new TextEmbeddingProcessor(),
     type: 'customComponent',
   },
   {
-    id: 'knn-index',
+    id: generateId('knn_index'),
     position: { x: 500, y: 500 },
     data: new KnnIndex(),
     type: 'customComponent',

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -21,29 +21,18 @@ const dummyNodes = [
     type: 'customComponent',
   },
   {
+    id: 'text-embedding-processor-2',
+    position: { x: 0, y: 200 },
+    data: new TextEmbeddingProcessor(),
+    type: 'customComponent',
+  },
+  {
     id: 'knn-index',
     position: { x: 500, y: 500 },
     data: new KnnIndex(),
     type: 'customComponent',
   },
 ] as ReactFlowComponent[];
-
-const dummyEdges = [
-  {
-    id: 'e1-2',
-    source: 'model',
-    target: 'ingest-pipeline',
-    style: {
-      strokeWidth: 2,
-      stroke: 'black',
-    },
-    markerEnd: {
-      type: 'arrow',
-      strokeWidth: 1,
-      color: 'black',
-    },
-  },
-] as ReactFlowEdge[];
 
 const initialState = {
   // TODO: fetch from server-side later
@@ -54,7 +43,7 @@ const initialState = {
       description: 'description for workflow 1',
       reactFlowState: {
         nodes: dummyNodes,
-        edges: dummyEdges,
+        edges: [] as ReactFlowEdge[],
       },
       template: {},
     },
@@ -64,7 +53,7 @@ const initialState = {
       description: 'description for workflow 2',
       reactFlowState: {
         nodes: dummyNodes,
-        edges: dummyEdges,
+        edges: [] as ReactFlowEdge[],
       },
       template: {},
     },

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -27,3 +27,8 @@ export enum COMPONENT_CATEGORY {
   INGEST_PROCESSORS = 'Ingest Processors',
   INDICES = 'Indices',
 }
+
+export enum COMPONENT_CLASS {
+  KNN_INDEX = 'knn_index',
+  TEXT_EMBEDDING_PROCESSOR = 'text_embedding_processor',
+}

--- a/public/utils/index.ts
+++ b/public/utils/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './constants';
+export * from './utils';

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Append 16 random characters
+export function generateId(prefix: string) {
+  const uniqueChar = () => {
+    // eslint-disable-next-line no-bitwise
+    return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
+  };
+  return `${prefix}_${uniqueChar()}${uniqueChar()}${uniqueChar()}${uniqueChar()}`;
+}


### PR DESCRIPTION
### Description

This PR adds the input and output handles to the general `WorkspaceComponent`. Specifically, we add an `InputHandle` and `OutputHandle` class which adds the `Handle` reactflow component dynamically based on the component spec. These classes configure the data within the input and output handles so they can be processed correctly.

Also adds a custom `isValidConnection` helper fn to determine if a connection from a source to target is allowed. Currently, we do basic validation that 1/ the base classes are the same and 2/ prevent multiple connections if the input handle does not allow it. Short video below demonstrates this.

Current logic assumes the output handle may be multiple classes (string[]). These are serialized/deserialized by turning them into a pipe-delimited string. The input handle is under the assumption to just have one class for now.

Additional clean up
- removed unnecessary `id` field from the component classes. The unique `id` for a node will just use the existing reactflow node that already has an `id`. When a user adds a component to the workspace (`onDrop()`), a random ID will be generated using the new `generateId` helper fn.
- formalizes the classes from type `string` to a `COMPONENT_CLASS` enum

Testing
- tested the `isValidConnection` fn works as expected for the different use cases
- tested that 0/1/multiple input & output handles renders correctly

[screen-capture (12).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/8017c349-28a6-4c0f-b65c-928a096c8221)


### Issues Resolved

Makes progress on #8, #10, and #16

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
