### PR TITLE
Add a component details side panel

### DIFF
--- a/public/app.tsx
+++ b/public/app.tsx
@@ -19,7 +19,7 @@ interface Props extends RouteComponentProps {}
 
 export const AiFlowDashboardsApp = (props: Props) => {
   const sidebar = (
-    <EuiPageSideBar style={{ minWidth: 190 }} hidden={false}>
+    <EuiPageSideBar style={{ minWidth: 190 }} hidden={false} paddingSize="l">
       <EuiSideNav
         style={{ width: 190 }}
         items={[
@@ -50,7 +50,10 @@ export const AiFlowDashboardsApp = (props: Props) => {
   return (
     <EuiPageTemplate
       template="empty"
-      pageContentProps={{ paddingSize: 'm' }}
+      paddingSize="none"
+      grow={true}
+      restrictWidth={false}
+      pageContentProps={{ paddingSize: 's' }}
       pageSideBar={sidebar}
     >
       <Switch>

--- a/public/pages/overview/overview.tsx
+++ b/public/pages/overview/overview.tsx
@@ -14,6 +14,14 @@ import {
 import { BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
 
+/**
+ * The overview page. This contains a detailed description on what
+ * this plugin offers, and links to different resources (blogs, demos,
+ * documentation, etc.)
+ *
+ * This may be hidden for the initial release until we have sufficient content
+ * such that this page adds enough utility & user value.
+ */
 export function Overview() {
   useEffect(() => {
     getCore().chrome.setBreadcrumbs([

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -20,6 +20,11 @@ export interface WorkflowDetailRouterProps {
 interface WorkflowDetailProps
   extends RouteComponentProps<WorkflowDetailRouterProps> {}
 
+/**
+ * The workflow details page. This is where users will configure, create, and
+ * test their created workflows. Additionally, can be used to load existing workflows
+ * to view details and/or make changes to them.
+ */
 export function WorkflowDetail(props: WorkflowDetailProps) {
   const { workflows } = useSelector((state: AppState) => state.workflows);
 

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -10,8 +10,8 @@ import { EuiPage, EuiPageBody } from '@elastic/eui';
 import { BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
 import { WorkflowDetailHeader } from './components';
-import { Workspace } from './workspace';
 import { AppState } from '../../store';
+import { ResizableWorkspace } from './workspace';
 
 export interface WorkflowDetailRouterProps {
   workflowId: string;
@@ -40,7 +40,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     <EuiPage>
       <EuiPageBody>
         <WorkflowDetailHeader workflow={workflow} />
-        <Workspace workflow={workflow} />
+        <ResizableWorkspace workflow={workflow} />
       </EuiPageBody>
     </EuiPage>
   );

--- a/public/pages/workflow_detail/workspace/component_details.tsx
+++ b/public/pages/workflow_detail/workspace/component_details.tsx
@@ -26,6 +26,11 @@ interface ComponentDetailsProps {
   isOpen: boolean;
 }
 
+/**
+ * A panel that will be nested in a resizable container to dynamically show
+ * the details and user-required inputs based on the selected component
+ * in the flow workspace.
+ */
 export function ComponentDetails(props: ComponentDetailsProps) {
   // TODO: use this instance to update the internal node state. ex: update field data in the selected node based
   // on user input

--- a/public/pages/workflow_detail/workspace/component_details.tsx
+++ b/public/pages/workflow_detail/workspace/component_details.tsx
@@ -44,6 +44,7 @@ export function ComponentDetails(props: ComponentDetailsProps) {
    * Hook provided by reactflow to listen on when nodes are selected / de-selected.
    * - populate panel content appropriately
    * - open the panel if a node is selected and the panel is closed
+   * - it is assumed that only one node can be selected at once
    */
   useOnSelectionChange({
     onChange: ({ nodes, edges }) => {

--- a/public/pages/workflow_detail/workspace/component_details.tsx
+++ b/public/pages/workflow_detail/workspace/component_details.tsx
@@ -21,12 +21,12 @@ import { InputFieldList } from '../workspace_component/input_field_list';
 // styling
 import './workspace-styles.scss';
 
-interface ComponentInputsProps {
+interface ComponentDetailsProps {
   onToggleChange: () => void;
   isOpen: boolean;
 }
 
-export function ComponentInputs(props: ComponentInputsProps) {
+export function ComponentDetails(props: ComponentDetailsProps) {
   // TODO: use this instance to update the internal node state. ex: update field data in the selected node based
   // on user input
   const { reactFlowInstance } = useContext(rfContext);

--- a/public/pages/workflow_detail/workspace/component_inputs.tsx
+++ b/public/pages/workflow_detail/workspace/component_inputs.tsx
@@ -3,9 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { Workflow } from '../../../../common';
+import React, { useState, useContext } from 'react';
+import { useOnSelectionChange } from 'reactflow';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiPanel,
+  EuiTitle,
+} from '@elastic/eui';
+import { ReactFlowComponent, ReactFlowEdge } from '../../../../common';
+import { rfContext } from '../../../store';
+import { InputFieldList } from '../workspace_component/input_field_list';
 
 // styling
 import './workspace-styles.scss';
@@ -13,15 +22,40 @@ import './workspace-styles.scss';
 interface ComponentInputsProps {}
 
 export function ComponentInputs(props: ComponentInputsProps) {
+  // TODO: use this instance to update the internal node state. ex: update field data in the selected node based
+  // on user input
+  const { reactFlowInstance } = useContext(rfContext);
+
+  const [selectedComponent, setSelectedComponent] = useState<
+    ReactFlowComponent
+  >();
+
+  // using custom hook provided by ReactFlow to populate the selected
+  // workspace component
+  useOnSelectionChange({
+    onChange: ({ nodes, edges }) => {
+      if (nodes && nodes.length > 0) {
+        setSelectedComponent(nodes[0]);
+      } else {
+        setSelectedComponent(undefined);
+      }
+    },
+  });
+
   return (
-    <EuiFlexGroup
-      direction="column"
-      gutterSize="none"
-      justifyContent="spaceBetween"
-      className="workspace-panel"
-    >
+    <EuiFlexGroup direction="column" gutterSize="m" className="workspace-panel">
       <EuiFlexItem className="resizable-panel-border">
-        <EuiText>Side panel</EuiText>
+        <EuiPanel paddingSize="s">
+          <>
+            <EuiTitle size="m">
+              <h2>{selectedComponent?.data.label || ''}</h2>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <InputFieldList
+              inputFields={selectedComponent?.data.fields || []}
+            />
+          </>
+        </EuiPanel>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workspace/component_inputs.tsx
+++ b/public/pages/workflow_detail/workspace/component_inputs.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { Workflow } from '../../../../common';
+
+// styling
+import './workspace-styles.scss';
+
+interface ComponentInputsProps {}
+
+export function ComponentInputs(props: ComponentInputsProps) {
+  return (
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="none"
+      justifyContent="spaceBetween"
+      className="workspace-panel"
+    >
+      <EuiFlexItem className="resizable-panel-border">
+        <EuiText>Side panel</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workspace/component_inputs.tsx
+++ b/public/pages/workflow_detail/workspace/component_inputs.tsx
@@ -73,7 +73,7 @@ export function ComponentInputs(props: ComponentInputsProps) {
             </>
           ) : (
             <EuiEmptyPrompt
-              iconType={'iInCircle'}
+              iconType={'cross'}
               title={<h2>No component selected</h2>}
               titleSize="s"
               body={

--- a/public/pages/workflow_detail/workspace/component_inputs.tsx
+++ b/public/pages/workflow_detail/workspace/component_inputs.tsx
@@ -11,15 +11,20 @@ import {
   EuiSpacer,
   EuiPanel,
   EuiTitle,
+  EuiEmptyPrompt,
+  EuiText,
 } from '@elastic/eui';
-import { ReactFlowComponent, ReactFlowEdge } from '../../../../common';
+import { ReactFlowComponent } from '../../../../common';
 import { rfContext } from '../../../store';
 import { InputFieldList } from '../workspace_component/input_field_list';
 
 // styling
 import './workspace-styles.scss';
 
-interface ComponentInputsProps {}
+interface ComponentInputsProps {
+  onToggleChange: () => void;
+  isOpen: boolean;
+}
 
 export function ComponentInputs(props: ComponentInputsProps) {
   // TODO: use this instance to update the internal node state. ex: update field data in the selected node based
@@ -30,12 +35,18 @@ export function ComponentInputs(props: ComponentInputsProps) {
     ReactFlowComponent
   >();
 
-  // using custom hook provided by ReactFlow to populate the selected
-  // workspace component
+  /**
+   * Hook provided by reactflow to listen on when nodes are selected / de-selected.
+   * - populate panel content appropriately
+   * - open the panel if a node is selected and the panel is closed
+   */
   useOnSelectionChange({
     onChange: ({ nodes, edges }) => {
       if (nodes && nodes.length > 0) {
         setSelectedComponent(nodes[0]);
+        if (!props.isOpen) {
+          props.onToggleChange();
+        }
       } else {
         setSelectedComponent(undefined);
       }
@@ -43,18 +54,38 @@ export function ComponentInputs(props: ComponentInputsProps) {
   });
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="m" className="workspace-panel">
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="none"
+      className="workspace-panel"
+    >
       <EuiFlexItem className="resizable-panel-border">
-        <EuiPanel paddingSize="s">
-          <>
-            <EuiTitle size="m">
-              <h2>{selectedComponent?.data.label || ''}</h2>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-            <InputFieldList
-              inputFields={selectedComponent?.data.fields || []}
+        <EuiPanel paddingSize="m">
+          {selectedComponent ? (
+            <>
+              <EuiTitle size="m">
+                <h2>{selectedComponent?.data.label || ''}</h2>
+              </EuiTitle>
+              <EuiSpacer size="s" />
+              <InputFieldList
+                inputFields={selectedComponent?.data.fields || []}
+              />
+            </>
+          ) : (
+            <EuiEmptyPrompt
+              iconType={'iInCircle'}
+              title={<h2>No component selected</h2>}
+              titleSize="s"
+              body={
+                <>
+                  <EuiText>
+                    Add a component, or select a component to view or edit its
+                    configuration.
+                  </EuiText>
+                </>
+              }
             />
-          </>
+          )}
         </EuiPanel>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workspace/index.ts
+++ b/public/pages/workflow_detail/workspace/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { Workspace } from './workspace';
+export { ResizableWorkspace } from './resizable_workspace';

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -2,6 +2,10 @@ $handle-color: $euiColorDarkestShade;
 $handle-color-valid: $euiColorSuccess;
 $handle-color-invalid: $euiColorDanger;
 
+.reactflow-workspace {
+  background: $euiColorEmptyShade;
+}
+
 .reactflow-parent-wrapper {
   display: flex;
   flex-grow: 1;

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -1,6 +1,6 @@
-$handle-color: #5a5a5a;
-$handle-color-valid: #55dd99;
-$handle-color-invalid: #ff6060;
+$handle-color: $euiColorDarkestShade;
+$handle-color-valid: $euiColorSuccess;
+$handle-color-invalid: $euiColorDanger;
 
 .reactflow-parent-wrapper {
   display: flex;
@@ -11,12 +11,6 @@ $handle-color-invalid: #ff6060;
 .reactflow-parent-wrapper .reactflow-wrapper {
   flex-grow: 1;
   height: 100%;
-}
-
-.workspace {
-  width: 80vh;
-  height: 50vh;
-  padding: 0;
 }
 
 .reactflow-workspace .react-flow__node {

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import { EuiResizableContainer } from '@elastic/eui';
 import { Workflow } from '../../../../common';
@@ -15,27 +15,48 @@ interface ResizableWorkspaceProps {
 }
 
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const collapseFn = useRef(
+    (id: string, options: { direction: 'left' | 'right' }) => {}
+  );
+
+  const onToggleChange = () => {
+    collapseFn.current('inputsPanel', { direction: 'left' });
+    setIsOpen(!isOpen);
+  };
+
   return (
     <EuiResizableContainer
       direction="horizontal"
       style={{ marginLeft: '-14px' }}
     >
-      {(EuiResizablePanel, EuiResizableButton) => (
-        <ReactFlowProvider>
-          <EuiResizablePanel
-            mode="main"
-            initialSize={60}
-            minSize="50%"
-            style={{ margin: 0, padding: 0 }}
-          >
-            <Workspace workflow={props.workflow} />
-          </EuiResizablePanel>
-          <EuiResizableButton />
-          <EuiResizablePanel mode="collapsible" initialSize={40} minSize="10%">
-            <ComponentInputs />
-          </EuiResizablePanel>
-        </ReactFlowProvider>
-      )}
+      {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
+        if (togglePanel) {
+          collapseFn.current = (panelId: string, { direction }) =>
+            togglePanel(panelId, { direction });
+        }
+
+        return (
+          <ReactFlowProvider>
+            <EuiResizablePanel mode="main" initialSize={75} minSize="50%">
+              <Workspace workflow={props.workflow} />
+            </EuiResizablePanel>
+            <EuiResizableButton />
+            <EuiResizablePanel
+              id="inputsPanel"
+              mode="collapsible"
+              initialSize={25}
+              minSize="10%"
+              onToggleCollapsedInternal={() => onToggleChange()}
+            >
+              <ComponentInputs
+                onToggleChange={onToggleChange}
+                isOpen={isOpen}
+              />
+            </EuiResizablePanel>
+          </ReactFlowProvider>
+        );
+      }}
     </EuiResizableContainer>
   );
 }

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -14,6 +14,10 @@ interface ResizableWorkspaceProps {
   workflow?: Workflow;
 }
 
+/**
+ * The overall workspace component that maintains state related to the 2 resizable
+ * panels - the ReactFlow workspace panel and the selected component details panel.
+ */
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const collapseFn = useRef(

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -8,7 +8,7 @@ import { ReactFlowProvider } from 'reactflow';
 import { EuiResizableContainer } from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { Workspace } from './workspace';
-import { ComponentInputs } from './component_inputs';
+import { ComponentDetails } from './component_details';
 
 interface ResizableWorkspaceProps {
   workflow?: Workflow;
@@ -49,7 +49,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
               minSize="10%"
               onToggleCollapsedInternal={() => onToggleChange()}
             >
-              <ComponentInputs
+              <ComponentDetails
                 onToggleChange={onToggleChange}
                 isOpen={isOpen}
               />

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -14,6 +14,8 @@ interface ResizableWorkspaceProps {
   workflow?: Workflow;
 }
 
+const COMPONENT_DETAILS_PANEL_ID = 'component_details_panel_id';
+
 /**
  * The overall workspace component that maintains state related to the 2 resizable
  * panels - the ReactFlow workspace panel and the selected component details panel.
@@ -25,7 +27,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   );
 
   const onToggleChange = () => {
-    collapseFn.current('inputsPanel', { direction: 'left' });
+    collapseFn.current(COMPONENT_DETAILS_PANEL_ID, { direction: 'left' });
     setIsOpen(!isOpen);
   };
 
@@ -47,7 +49,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             </EuiResizablePanel>
             <EuiResizableButton />
             <EuiResizablePanel
-              id="inputsPanel"
+              id={COMPONENT_DETAILS_PANEL_ID}
               mode="collapsible"
               initialSize={25}
               minSize="10%"

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiResizableContainer } from '@elastic/eui';
+import { Workflow } from '../../../../common';
+import { Workspace } from './workspace';
+import { ComponentInputs } from './component_inputs';
+
+interface ResizableWorkspaceProps {
+  workflow?: Workflow;
+}
+
+export function ResizableWorkspace(props: ResizableWorkspaceProps) {
+  return (
+    <EuiResizableContainer
+      direction="horizontal"
+      style={{ marginLeft: '-14px' }}
+    >
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel
+            mode="main"
+            initialSize={80}
+            minSize="50%"
+            style={{ margin: 0, padding: 0 }}
+          >
+            <Workspace workflow={props.workflow} />
+          </EuiResizablePanel>
+          <EuiResizableButton />
+          <EuiResizablePanel mode="collapsible" initialSize={20} minSize="10%">
+            <ComponentInputs />
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
+  );
+}

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { ReactFlowProvider } from 'reactflow';
 import { EuiResizableContainer } from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { Workspace } from './workspace';
@@ -20,20 +21,20 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       style={{ marginLeft: '-14px' }}
     >
       {(EuiResizablePanel, EuiResizableButton) => (
-        <>
+        <ReactFlowProvider>
           <EuiResizablePanel
             mode="main"
-            initialSize={80}
+            initialSize={60}
             minSize="50%"
             style={{ margin: 0, padding: 0 }}
           >
             <Workspace workflow={props.workflow} />
           </EuiResizablePanel>
           <EuiResizableButton />
-          <EuiResizablePanel mode="collapsible" initialSize={20} minSize="10%">
+          <EuiResizablePanel mode="collapsible" initialSize={40} minSize="10%">
             <ComponentInputs />
           </EuiResizablePanel>
-        </>
+        </ReactFlowProvider>
       )}
     </EuiResizableContainer>
   );

--- a/public/pages/workflow_detail/workspace/workspace-styles.scss
+++ b/public/pages/workflow_detail/workspace/workspace-styles.scss
@@ -1,0 +1,12 @@
+.workspace-panel {
+  // this ratio will allow the workspace to render on a standard
+  // laptop (3024 x 1964) without introducing overflow/scrolling
+  height: 60vh;
+  padding: 0;
+}
+
+.resizable-panel-border {
+  border-style: groove;
+  border-color: gray;
+  border-width: 1px;
+}

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -23,6 +23,7 @@ import { DeletableEdge } from '../workspace_edge';
 // styling
 import 'reactflow/dist/style.css';
 import './reactflow-styles.scss';
+import './workspace-styles.scss';
 import '../workspace_edge/deletable-edge-styles.scss';
 
 interface WorkspaceProps {
@@ -117,17 +118,11 @@ export function Workspace(props: WorkspaceProps) {
   return (
     <EuiFlexGroup
       direction="column"
-      gutterSize="m"
+      gutterSize="none"
       justifyContent="spaceBetween"
-      className="workspace"
+      className="workspace-panel"
     >
-      <EuiFlexItem
-        style={{
-          borderStyle: 'groove',
-          borderColor: 'gray',
-          borderWidth: '1px',
-        }}
-      >
+      <EuiFlexItem className="resizable-panel-border">
         {/**
          * We have these wrapper divs & reactFlowWrapper ref to control and calculate the
          * ReactFlow bounds when calculating node positioning.

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -11,6 +11,7 @@ import ReactFlow, {
   useNodesState,
   useEdgesState,
   addEdge,
+  BackgroundVariant,
 } from 'reactflow';
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { rfContext, setDirty } from '../../../store';
@@ -144,7 +145,10 @@ export function Workspace(props: WorkspaceProps) {
               fitView
             >
               <Controls />
-              <Background />
+              <Background
+                color="#343741"
+                variant={'dots' as BackgroundVariant}
+              />
             </ReactFlow>
           </div>
         </div>

--- a/public/pages/workflow_detail/workspace_component/input_field_list.tsx
+++ b/public/pages/workflow_detail/workspace_component/input_field_list.tsx
@@ -19,7 +19,7 @@ interface InputFieldListProps {
 
 export function InputFieldList(props: InputFieldListProps) {
   return (
-    <EuiFlexItem>
+    <EuiFlexItem grow={false}>
       {props.inputFields?.map((field, idx) => {
         let el;
         switch (field.type) {

--- a/public/pages/workflow_detail/workspace_component/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace_component/workspace_component.tsx
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiCard } from '@elastic/eui';
 import { IComponent } from '../../../component_types';
-import { InputFieldList } from './input_field_list';
-import { NewOrExistingTabs } from './new_or_existing_tabs';
 import { InputHandle } from './input_handle';
 import { OutputHandle } from './output_handle';
 
@@ -23,24 +21,9 @@ interface WorkspaceComponentProps {
 export function WorkspaceComponent(props: WorkspaceComponentProps) {
   const component = props.data;
 
-  const [selectedTabId, setSelectedTabId] = useState<string>('existing');
-
-  const isCreatingNew = component.allowsCreation && selectedTabId === 'new';
-  const fieldsToDisplay = isCreatingNew
-    ? component.createFields
-    : component.fields;
-
   return (
     <EuiCard title={component.label}>
       <EuiFlexGroup direction="column">
-        {/* <EuiFlexItem>
-          {component.allowsCreation ? (
-            <NewOrExistingTabs
-              setSelectedTabId={setSelectedTabId}
-              selectedTabId={selectedTabId}
-            />
-          ) : undefined}
-        </EuiFlexItem> */}
         {component.inputs?.map((input, index) => {
           return (
             <EuiFlexItem key={index}>
@@ -48,7 +31,7 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
             </EuiFlexItem>
           );
         })}
-        <InputFieldList inputFields={fieldsToDisplay} />
+        {/* TODO: finalize from UX what we show in the component itself. Readonly fields? Configure in the component JSON definition? */}
         {component.outputs?.map((output, index) => {
           return (
             <EuiFlexItem key={index}>

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -10,6 +10,13 @@ import { UseCase } from './use_case';
 
 interface NewWorkflowProps {}
 
+/**
+ * TODO: may rename this later on.
+ *
+ * Contains the searchable library of templated workflows based
+ * on a variety of use cases. Can click on them to load in a pre-configured
+ * workflow for users to start with.
+ */
 export function NewWorkflow(props: NewWorkflowProps) {
   return (
     <EuiFlexGrid columns={3} gutterSize="l">

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -12,6 +12,9 @@ import { columns } from './columns';
 
 interface WorkflowListProps {}
 
+/**
+ * The searchable list of created workflows.
+ */
 export function WorkflowList(props: WorkflowListProps) {
   const { workflows } = useSelector((state: AppState) => state.workflows);
 

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -41,6 +41,11 @@ function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
   });
 }
 
+/**
+ * The base workflows page. From here, users can toggle between views to access
+ * existing created workflows, or explore the library of workflow templates
+ * to get started on a new workflow.
+ */
 export function Workflows(props: WorkflowsProps) {
   const { workflows } = useSelector((state: AppState) => state.workflows);
 


### PR DESCRIPTION
### Description

This PR adds a resizable panel that dynamically shows component details based on the selected component in the ReactFlow workspace, using ReactFlow's [useOnSelectionChange() hook](https://reactflow.dev/docs/api/hooks/use-on-selection-change/). If none are selected, it shows an empty state. If the panel is closed, it will automatically open when a user selects a component in the workspace. The panel content replaces what used to be in the components themselves; this is where the users will view / edit / update user-provided input to the individual components. Form validation & persisting input is still a TODO.

Other details:
- nests the entire workspace in a new `ResizableWorkspace` component to contain both the ReactFlow workspace, and the new `ComponentDetails` panel.
- nests the entire workspace in a `ReactFlowProvider` such that child components can access the various [hooks provided by ReactFlow](https://reactflow.dev/docs/api/hooks/use-react-flow/)
- cleans up some styling to maximize the space better and make component sizing and growing functionality consistent
- adds few high-level comments for the base page components

Demo video:

[screen-capture (14).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/cf9abb7b-a1aa-480e-a7cd-6f1f029e04a4)


### Issues Resolved

Makes progress on #10 , #16 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
