### PR TITLE
Add node deletion functionality in Workspace

### DIFF
--- a/public/component_types/interfaces.ts
+++ b/public/component_types/interfaces.ts
@@ -77,3 +77,11 @@ export interface IComponent {
   createFields?: IComponentField[];
   outputs?: IComponentOutput[];
 }
+
+/**
+ * We need to include some extra instance-specific data to the ReactFlow component
+ * to perform extra functionality, such as deleting the node from the ReactFlowInstance.
+ */
+export interface IComponentData extends IComponent {
+  id: string;
+}

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -16,7 +16,7 @@ import ReactFlow, {
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { rfContext, setDirty } from '../../../store';
 import { IComponent, Workflow } from '../../../../common';
-import { generateId } from '../../../utils';
+import { generateId, initComponentData } from '../../../utils';
 import { getCore } from '../../../services';
 import { WorkspaceComponent } from '../workspace_component';
 import { DeletableEdge } from '../workspace_edge';
@@ -84,11 +84,12 @@ export function Workspace(props: WorkspaceProps) {
 
       // TODO: remove hardcoded values when more component info is passed in the event.
       // Only keep the calculated 'position' field.
+      const id = generateId(nodeData.type);
       const newNode = {
-        id: generateId(nodeData.type),
+        id,
         type: nodeData.type,
         position,
-        data: nodeData,
+        data: initComponentData(nodeData, id),
         style: {
           background: 'white',
         },

--- a/public/pages/workflow_detail/workspace_component/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace_component/workspace_component.tsx
@@ -3,14 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiCard } from '@elastic/eui';
-import { IComponent } from '../../../component_types';
+import React, { useContext } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCard,
+  EuiText,
+  EuiTitle,
+  EuiButtonIcon,
+} from '@elastic/eui';
+import { rfContext } from '../../../store';
+import { IComponentData } from '../../../component_types';
 import { InputHandle } from './input_handle';
 import { OutputHandle } from './output_handle';
 
 interface WorkspaceComponentProps {
-  data: IComponent;
+  data: IComponentData;
 }
 
 /**
@@ -20,10 +28,36 @@ interface WorkspaceComponentProps {
  */
 export function WorkspaceComponent(props: WorkspaceComponentProps) {
   const component = props.data;
+  const { deleteNode } = useContext(rfContext);
 
   return (
-    <EuiCard title={component.label}>
+    <EuiCard
+      textAlign="left"
+      title={
+        <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h3>{component.label}</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="trash"
+              onClick={() => {
+                deleteNode(component.id);
+              }}
+              aria-label="Delete"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    >
       <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiText size="s" color="subdued">
+            {component.description}
+          </EuiText>
+        </EuiFlexItem>
         {component.inputs?.map((input, index) => {
           return (
             <EuiFlexItem key={index}>
@@ -31,7 +65,6 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
             </EuiFlexItem>
           );
         })}
-        {/* TODO: finalize from UX what we show in the component itself. Readonly fields? Configure in the component JSON definition? */}
         {component.outputs?.map((output, index) => {
           return (
             <EuiFlexItem key={index}>

--- a/public/store/context/react_flow_context_provider.tsx
+++ b/public/store/context/react_flow_context_provider.tsx
@@ -5,7 +5,7 @@
 
 import React, { createContext, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Edge } from 'reactflow';
+import { Edge, Node } from 'reactflow';
 import { setDirty } from '../reducers';
 
 const initialValues = {
@@ -30,8 +30,19 @@ export function ReactFlowContextProvider({ children }: any) {
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
 
   const deleteNode = (nodeId: string) => {
-    // TODO: implement node deletion
-    // reactFlowInstance.setNodes(...)
+    reactFlowInstance.setNodes(
+      reactFlowInstance.getNodes().filter((node: Node) => node.id !== nodeId)
+    );
+    // Also delete any dangling edges attached to the component
+    reactFlowInstance.setEdges(
+      reactFlowInstance
+        .getEdges()
+        .filter(
+          (edge: Edge) => edge.source !== nodeId && edge.target !== nodeId
+        )
+    );
+
+    dispatch(setDirty());
   };
 
   const deleteEdge = (edgeId: string) => {

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -11,26 +11,30 @@ import {
   KnnIndex,
   TextEmbeddingProcessor,
   generateId,
+  initComponentData,
 } from '../../../common';
 
 // TODO: remove after fetching from server-side
+const id1 = generateId('text_embedding_processor');
+const id2 = generateId('text_embedding_processor');
+const id3 = generateId('knn_index');
 const dummyNodes = [
   {
-    id: generateId('text_embedding_processor'),
+    id: id1,
     position: { x: 0, y: 500 },
-    data: new TextEmbeddingProcessor().toObj(),
+    data: initComponentData(new TextEmbeddingProcessor().toObj(), id1),
     type: 'customComponent',
   },
   {
-    id: generateId('text_embedding_processor'),
+    id: id2,
     position: { x: 0, y: 200 },
-    data: new TextEmbeddingProcessor().toObj(),
+    data: initComponentData(new TextEmbeddingProcessor().toObj(), id2),
     type: 'customComponent',
   },
   {
-    id: generateId('knn_index'),
+    id: id3,
     position: { x: 500, y: 500 },
-    data: new KnnIndex().toObj(),
+    data: initComponentData(new KnnIndex().toObj(), id3),
     type: 'customComponent',
   },
 ] as ReactFlowComponent[];

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { IComponent, IComponentData } from '../../common';
+
 // Append 16 random characters
 export function generateId(prefix: string) {
   const uniqueChar = () => {
@@ -10,4 +12,16 @@ export function generateId(prefix: string) {
     return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
   };
   return `${prefix}_${uniqueChar()}${uniqueChar()}${uniqueChar()}${uniqueChar()}`;
+}
+
+// Adding any instance metadata. Converting the base IComponent obj into
+// an instance-specific IComponentData obj.
+export function initComponentData(
+  data: IComponent,
+  componentId: string
+): IComponentData {
+  return {
+    ...data,
+    id: componentId,
+  } as IComponentData;
 }


### PR DESCRIPTION
### Description

Adds a delete button to the header in the workflow component. Implements `deleteNode()` to remove the node and any related edges via `reactFlowInstance` context. Updates Workspace state as well (see video of `Save` button becoming available after deletion). Note that in order to delete, we need to propagate the ID into the `data` field of the ReactFlow component. We do this via a new `initComponentData()` fn to populate instance-specific data, such as ID. There may be more of these types of fields in the future, so we leave the new interface and fn generic.

Also cleans up the layout slightly to more closely align with UX mockups.

Demo video:

[screen-capture (16).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/29e06bfe-f96f-4f03-82c3-351d707a381c)

### Issues Resolved

Makes progress on #10 , #16 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
